### PR TITLE
Finalize ur_interfaces public repo discussions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ set(msg_files
   "msg/SafetyStatus.msg"
   "msg/SpeedSliderFraction.msg"
   "msg/TCPState.msg"
-  "msg/ProgramState.msg"
   "msg/ToolOutputMode.msg"
   "msg/VoltageCurrentStamped.msg"
   "msg/WorldModelNames.msg"

--- a/msg/Analog.msg
+++ b/msg/Analog.msg
@@ -1,6 +1,6 @@
 std_msgs/Header header
-uint8 CURRENT=0
-uint8 VOLTAGE=1
+uint8 CURRENT = 0
+uint8 VOLTAGE = 1
 
-uint8 domain # can be VOLTAGE or CURRENT
-float32 value
+uint8 domain # can be VOLTAGE or CURRENT, must match SetAnalogOutput.srv
+float32 data

--- a/msg/ControlCycle.msg
+++ b/msg/ControlCycle.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-uint64 cycle_counter
+uint64 data

--- a/msg/Current.msg
+++ b/msg/Current.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-float32 current
+float32 data

--- a/msg/DigitalPort.msg
+++ b/msg/DigitalPort.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-bool[] state
+bool[] data

--- a/msg/JointTemperature.msg
+++ b/msg/JointTemperature.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-float32[6] joint_temperatures
+float32[6] data

--- a/msg/JointVoltage.msg
+++ b/msg/JointVoltage.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-float64[6] voltages
+float64[6] data

--- a/msg/ProgramState.msg
+++ b/msg/ProgramState.msg
@@ -1,5 +1,0 @@
-string STOPPED=STOPPED
-string PLAYING=PLAYING
-string PAUSED=PAUSED
-
-string state

--- a/msg/RobotMode.msg
+++ b/msg/RobotMode.msg
@@ -9,4 +9,4 @@ int8 RUNNING=7
 int8 UPDATING_FIRMWARE=8
 
 std_msgs/Header header
-int8 value
+int8 data

--- a/msg/RuntimeState.msg
+++ b/msg/RuntimeState.msg
@@ -8,4 +8,4 @@ int8 PROGRAM_STATE_RESUMING=5
 int8 PROGRAM_STATE_RETRACTING=6
 
 std_msgs/Header header
-int8 value
+int8 data

--- a/msg/SafetyStatus.msg
+++ b/msg/SafetyStatus.msg
@@ -13,4 +13,4 @@ int8 AUTOMATIC_MODE_SAFEGUARD_STOP=12
 int8 SYSTEM_THREE_POSITION_ENABLING_STOP=13
 
 std_msgs/Header header
-int8 safety_state
+int8 data

--- a/msg/SpeedSliderFraction.msg
+++ b/msg/SpeedSliderFraction.msg
@@ -1,2 +1,2 @@
 std_msgs/Header header
-float64 speed_scale
+float64 data

--- a/msg/WorldModelNames.msg
+++ b/msg/WorldModelNames.msg
@@ -1,3 +1,3 @@
 std_msgs/Header header
 
-std_msgs/String[] names
+std_msgs/String[] data

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ur_interfaces</name>
-  <version>0.0.1</version>
+  <version>0.0.2</version>
   <description>A package containing ROS2 ur message definitions.</description>
   <maintainer email="support@universal-robots.com">Universal Robots A/S</maintainer>
   <license>BSD-3-Clause</license>

--- a/srv/GetProgramState.srv
+++ b/srv/GetProgramState.srv
@@ -1,5 +1,5 @@
 ---
-ProgramState state
+RuntimeState state
 string program_name
 string answer
 bool success

--- a/srv/SetAnalogOutput.srv
+++ b/srv/SetAnalogOutput.srv
@@ -1,6 +1,6 @@
 # Note: 'fun' is short for function of the pin to be selected
-bool OUTPUT_CURRENT = 0
-bool OUTPUT_VOLTAGE = 1
+uint8 CURRENT = 0
+uint8 VOLTAGE = 1
 
 # The value for pin [0-1]
 
@@ -9,7 +9,7 @@ bool OUTPUT_VOLTAGE = 1
 
 # request fields
 int8 pin
-bool output_type
-float64 value
+uint8 output_type # can be VOLTAGE or CURRENT, must match Analog.msg
+float64 data
 ---
 bool success


### PR DESCRIPTION
Renamed fields to "data" unless there is a good reason for more specific name. bool type replaced by uint8 for domain in SetAnalogOutput.srv constant names renamed to be the same as in Analog.msg