### PR TITLE
Release/7.0.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package urinterfaces
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+7.0.0 (2025-01-08)
+------------------
 * Update msg, srv and action files (`#4 <https://github.com/UniversalRobots/ur_interfaces/issues/4>`_)
 * Update metainfo (`#5 <https://github.com/UniversalRobots/ur_interfaces/issues/5>`_)
 * Update ci (`#3 <https://github.com/UniversalRobots/ur_interfaces/issues/3>`_)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,13 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package urinterfaces
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Forthcoming
+-----------
+* Update msg, srv and action files (`#4 <https://github.com/UniversalRobots/ur_interfaces/issues/4>`_)
+* Update metainfo (`#5 <https://github.com/UniversalRobots/ur_interfaces/issues/5>`_)
+* Update ci (`#3 <https://github.com/UniversalRobots/ur_interfaces/issues/3>`_)
+* Add CI and pre-commit `#1 <https://github.com/UniversalRobots/ur_interfaces/issues/1>`_ from UniversalRobots/ci
+* Add dependency on action_msgs
+* Introducing new Universal Robots urinterfaces repository
+* Contributors: Ali Ekber Celik, Felix Exner, Michal Milkowski, Viktor Lukacs

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>urinterfaces</name>
-  <version>0.0.3</version>
+  <version>7.0.0</version>
   <description>A package containing ROS2 ur message definitions.</description>
   <maintainer email="ros@universal-robots.com">Universal Robots A/S</maintainer>
   <license>BSD-3-Clause</license>


### PR DESCRIPTION
This creates a release that matches our internal urinterfaces version. I've created a CHANGELOG and used ros tooling for setting up the release as if it was a binary release. We *could* do a binary release from that directly.

This should best be rebase-merged. I will push the `7.0.0` tag once this is merged along a `polyscope_10.7` tag.